### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: perl
+
+arch:
+ - amd64
+ - ppc64le
+ 
 perl:
-    - "5.24"
-    - "5.22"
-    - "5.20"
-    - "5.18"
-    - "5.16"
-    - "5.14"
+    - "5.26"
+    - "5.28"
+    - "5.30"
 
 before_install:
   - cpanm --notest Perl::Tidy


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added after updating the newer perl version and  I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/MARC-Parser-RAW/builds/200462806

Please have a look.

Regards,
Manish